### PR TITLE
Store OpenAI API Key in `config.json`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,20 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as readline from "readline";
+import * as readlinePromises from "readline/promises";
 import { exec } from "child_process";
 import { OpenAiAPI, OllamaAPI } from "./llm";
 
 import { ChatHistory } from "./history";
-import { Config, DEFAULT_OLLAMA_MODEL, DEFAULT_OPENAI_MODEL } from "./config";
+import {
+  Config,
+  DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OPENAI_MODEL,
+  requestApiKey,
+} from "./config";
 import { Git } from "./git";
 
 const LOZ_DEBUG = process.env.DEBUG === "true" ? true : false;
-
-const readline = require("readline");
 
 require("dotenv").config();
 
@@ -83,33 +88,39 @@ export class Loz {
 
     await this.loadingConfigFromJSONFile();
 
-    let api = this.checkAPI();
+    const api = this.checkAPI() || "openai";
 
-    if (api === "openai") {
-      this.checkEnv();
-      this.llmAPI = new OpenAiAPI();
-      this.defaultSettings.model =
-        this.config.get("model")?.value || DEFAULT_OPENAI_MODEL;
-    } else if (this.checkAPI() === "ollama") {
+    if (api === "ollama") {
       const result = await runShellCommand("ollama --version");
       if (DEBUG) console.log(result);
       if (result.indexOf("ollama") === -1) {
         console.log(
-          "Please install ollama with llama2 and codellama first: see https://ollama.ai/download \n"
+          "Please install ollama with llama2 and codellama first: see https://ollama.ai/download \n",
         );
         process.exit(1);
       }
       this.llmAPI = new OllamaAPI();
       this.defaultSettings.model =
         this.config.get("model")?.value || DEFAULT_OLLAMA_MODEL;
-    } else {
-      // default to openai
-      this.checkEnv();
-      this.llmAPI = new OpenAiAPI();
-      this.config.set("api", "openai");
-      this.defaultSettings.model =
-        this.config.get("model")?.value || DEFAULT_OPENAI_MODEL;
+      return true;
     }
+
+    let apiKey = this.config.get("openai.apikey")?.value;
+    if (!apiKey) {
+      const rl = readlinePromises.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+      apiKey = await requestApiKey(rl);
+      this.config.set("openai.apikey", apiKey);
+      rl.close();
+    }
+    this.llmAPI = new OpenAiAPI(apiKey);
+    this.config.set("api", "openai");
+    this.defaultSettings.model =
+      this.config.get("model")?.value || DEFAULT_OPENAI_MODEL;
+
+    // TODO: show error if api is wrong
 
     return true;
   }
@@ -122,16 +133,6 @@ export class Loz {
   checkAPI() {
     //console.log("API: " + this.config.get("api")?.value);
     return this.config.get("api")?.value;
-  }
-
-  checkEnv() {
-    if (process.env.OPENAI_API_KEY === undefined) {
-      console.error("Please set OPENAI_API_KEY in your environment variables");
-      // system end
-      process.exit(1);
-    }
-
-    return true;
   }
 
   // Save chat history (JSON) to file.

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -15,9 +15,9 @@ abstract class LLMService {
 }
 
 export class OpenAiAPI extends LLMService {
-  constructor() {
+  constructor(apiKey: string) {
     super();
-    this.api = new OpenAI();
+    this.api = new OpenAI({ apiKey });
   }
   async completion(params: LLMSettings) {
     const gptParams: OpenAI.Chat.ChatCompletionCreateParams = {

--- a/test/a.loz.test.ts
+++ b/test/a.loz.test.ts
@@ -34,18 +34,6 @@ describe("Test OpenAI API", () => {
   });
 });
 
-describe("Test Loz class", () => {
-  //  npm test --  --grep=Loz.checkEnv
-  describe("loz.checkEnv", () => {
-    it("should return true", () => {
-      let loz = new Loz();
-
-      const result = loz.checkEnv();
-      expect(result).to.equal(true);
-    });
-  });
-});
-
 if (process.env.LOZ_LOCAL_TEST === "true") {
   describe("Loz.ollama", () => {
     it("should return true", async () => {


### PR DESCRIPTION
## Summary
The main purpose of this PR is to modify the behavior of the CLI so that it generates a `config.json` file containing the API Key instead of fetching it from an environment variable (`OPENAI_API_KEY`). There are a couple of issues with using the environment variable approach:

**Incompatibility with Other Programs**: If other programs also rely on the `OPENAI_API_KEY`, they won’t be able to use different API keys independently.
**Security Risk**: Since `OPENAI_API_KEY` is a well-known key used by the OpenAI library, leaving it exposed in environment variables could lead to potential security risks. Malware or unauthorized access might exploit this key, resulting in unexpected charges.

## Changes

- Add `LOZ` prefix to `OPENAI_API_KEY` but keep `OPENAI_API_KEY` for a legacy.
- Use `readlinePromises` instead of `readline` in `src/config/index.ts` and `src/index.ts`.
- Remove the `checkEnv` method from `src/index.ts` as it is no longer needed.
- Pass the `apiKey` to the `OpenAiAPI` constructor in `src/llm/index.ts`.
- Remove the `checkEnv` test case from `test/a.loz.test.ts` as it is no longer needed.



Could you please review my pull request?
And thank you for making this project! Your hard work and dedication are greatly appreciated.

감사합니다. 새해 복 많이 받으세요.