### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Additionally, you can change the model by entering:
 or
 
 ```
-> config model codelamma
+> config model codellama
 ```
 
 You can check the current settings by entering:


### PR DESCRIPTION
There is wrong command in example command.